### PR TITLE
add: company-logo component

### DIFF
--- a/components/atoms/CompanyLogo/CompanyLogo.tsx
+++ b/components/atoms/CompanyLogo/CompanyLogo.tsx
@@ -1,0 +1,20 @@
+import React, { FC } from 'react';
+
+interface ICompanyLogo {
+  url: string;
+  name: string;
+}
+
+const CompanyLogo: FC<ICompanyLogo> = props => {
+  const { url, name } = props;
+
+  return (
+    <img
+      src={url}
+      alt={`${name}.svg`}
+      className="CompanyLogo"
+    />
+  );
+};
+
+export default CompanyLogo;


### PR DESCRIPTION
This is the "CompanyLogo" component that is meant to be used across several, if not all, apps.

NOTE: This component doesn't have any styling (e.g. width/height) because I presumed that client companies will provide our admin with logos which have previously agreed upon i.e. ideal dimensions. If this turns out to be false, we will add our own styling.