### PR TITLE
added client domain type

### DIFF
--- a/graphql/mutations/authentication.mutation.graphql
+++ b/graphql/mutations/authentication.mutation.graphql
@@ -61,8 +61,16 @@ mutation UpdateIdentityPassword(
   )
 }
 
-mutation MfaAccessToken($email: String!, $password: String!) {
-  mfaAccessToken(email: $email, password: $password) {
+mutation MfaAccessToken(
+  $email: String!
+  $password: String!
+  $clientDomainType: ClientDomainType!
+) {
+  mfaAccessToken(
+    email: $email
+    password: $password
+    clientDomainType: $clientDomainType
+  ) {
     mfaAccessToken
   }
 }
@@ -75,6 +83,13 @@ mutation MfaAuthenticate($mfaAccessToken: String!, $mfaCode: String!) {
   }
 }
 
-mutation RequestMfaCode($mfaAccessToken: String!) {
-  requestMfaCode(mfaAccessToken: $mfaAccessToken)
+mutation RequestMfaCode(
+  $mfaAccessToken: String!
+  $clientDomainType: ClientDomainType!
+) {
+  requestMfaCode(
+    mfaAccessToken: $mfaAccessToken
+
+    clientDomainType: $clientDomainType
+  )
 }

--- a/views/Authentication/Login/Login.tsx
+++ b/views/Authentication/Login/Login.tsx
@@ -2,6 +2,7 @@ import { FC, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import {
+  ClientDomainType,
   useAuthenticateMutation,
   useMfaAccessTokenMutation,
 } from '../../../../../generated/graphql';
@@ -156,6 +157,7 @@ const Login: FC<ILogin> = ({
                   variables: {
                     email: email,
                     password: password,
+                    clientDomainType: ClientDomainType.PdfAppDomain,
                   },
                 });
               }

--- a/views/Authentication/TwoFactorAuthentication/TwoFactorAuthentication.tsx
+++ b/views/Authentication/TwoFactorAuthentication/TwoFactorAuthentication.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
+  ClientDomainType,
   useMfaAuthenticateMutation,
   useRequestMfaCodeMutation,
 } from '../../../../../generated/graphql';
@@ -116,6 +117,7 @@ const TwoFactorAuthentication: FC<ITwoFactorAuthentication> = ({
     requestMfaCode({
       variables: {
         mfaAccessToken: mfaAccessToken ? mfaAccessToken : '',
+        clientDomainType: ClientDomainType.PdfAppDomain,
       },
     });
   };


### PR DESCRIPTION
This is a fix includes `clientDomainType`  which was added while ago. Because pdf client was not getting release that's why it was not required. Currently with latest backend this fix is required